### PR TITLE
Adds work_experience and education methods to FacebookProfileScraper

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,8 @@ profile.picture # => "https://scontent-cdg2-1.xx.fbcdn.net/...3716_n.jpg?oh=7fb3
 profile.city # => "Palo Alto, California"
 profile.about # => "I'm trying to make the world a more open place."
 profile.quote # => "Fortune favors the bold...." 
+profile.work_experience # =>  [{:name=>"Chan Zuckerberg Initiative", :meta_data=>["December 1, 2015 to present"]}, {:name=>"Facebook", :meta_data=>["Founder and CEO", "February 4, 2004 to present", "Palo Alto, California"]}]
+profile.education # =>  [{:name=>"Harvard University", :meta_data=>["Sep 2002 to May 2004", "Computer Science", "Psychology", "Cambridge, Massachusetts"]}, {:name=>"Phillips Exeter Academy", :meta_data=>["Class of 2002", "Classics"]}, {:name=>"Ardsley High School", :meta_data=>["Sep 1998 to Jun 2000", "Ardsley, New York"]}]
 ```
+
+note: if profile.education or profile.work_experience have no results, it will return an empty array `[]`

--- a/lib/facebook-profile-scraper.rb
+++ b/lib/facebook-profile-scraper.rb
@@ -86,7 +86,6 @@ class FacebookProfileScraper
         school[:meta_data] = ''
         school[:name] = div.css('a').text
         div.css('div.fsm').each do |school_meta_data_object| 
-          byebug
           school_meta_data = school_meta_data_object.text
           if school_meta_data.include?(' · ')
             school[:meta_data] = school_meta_data.split(' · ')

--- a/lib/facebook-profile-scraper.rb
+++ b/lib/facebook-profile-scraper.rb
@@ -54,4 +54,80 @@ class FacebookProfileScraper
     value.empty? ? nil : value
   end
 
+  def work_experience
+    work_experience = []
+    begin
+      @parsed_page.css('div[data-pnref=work] .fbEditProfileViewExperience').each do |div| 
+        work = {}
+        work[:name] = ''
+        work[:meta_data] = ''
+        work[:name] = div.css('a').text
+        div.css('div.fsm').each do |work_meta_data_object| 
+          work_meta_data = work_meta_data_object.text
+          if work_meta_data.include?(' · ')
+            work[:meta_data] = work_meta_data.split(' · ')
+          else
+            work[:meta_data] = [work_meta_data]
+          end
+        end
+        work_experience << work
+      end
+    rescue
+    end
+    work_experience
+  end
+
+  def education
+    education = []
+    begin
+      @parsed_page.css('div[data-pnref=edu] .fbEditProfileViewExperience').each do |div| 
+        school = {}
+        school[:name] = ''
+        school[:meta_data] = ''
+        school[:name] = div.css('a').text
+        div.css('div.fsm').each do |school_meta_data_object| 
+          byebug
+          school_meta_data = school_meta_data_object.text
+          if school_meta_data.include?(' · ')
+            school[:meta_data] = school_meta_data.split(' · ')
+          else
+            school[:meta_data] = [school_meta_data]
+          end
+        end
+        education << school
+      end
+    rescue
+    end
+    education
+  end
+
+  # def favorites
+  # end
+
+  # def favorite_athlete
+  # end
+
+  # def favorite_sports_teams
+  # end
+
+  # def favorite_movies
+  # end
+
+  # def favorite_games
+  # end
+
+  # def favorite_television
+  # end
+
+  # def favorite_interests
+  # end
+
+  # def favorite_music
+  # end
+
+  # def favorite_activities
+  # end
+
+  # def favorite_books
+  # end
 end


### PR DESCRIPTION
Adds `FacebookProfileScraper#work_experience` and `FacebookProfileScraper.education`. These methods will return an array of hashes that contain `:name` and `meta_data`. Name will be the name of the school based on the link. 

`meta_data` is the extra data that is underneath the link on the page. It will usually be year data, location, or (in the case of work_experience) job title. The three data types (year, location, job title) do not always exist, or do they always follow the same pattern. Instead of attempting to determine which job of data each is, I just added them to an array. 

To get those different pieces of meta_data, they are separated by ` · `. I used `#.split` to make an array out of that text. 

I added methods I want to work on next as time permits. They are commented out in case someone else wants to work on them. 

I also added code to `README.md` so new users can see how those new methods work. 

This closes #2 .